### PR TITLE
Keep the alternate file on rename

### DIFF
--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -21,7 +21,7 @@ command! -bar -bang Remove :Unlink<bang>
 command! -bar -nargs=1 -bang -complete=file Rename :
       \ let s:file = expand('%:p') |
       \ setlocal modified |
-      \ saveas<bang> <args> |
+      \ keepalt saveas<bang> <args> |
       \ if s:file !=# expand('%:p') |
       \   call delete(s:file) |
       \ endif |


### PR DESCRIPTION
I had pretty much this exact function in my vimrc. My version uses keepalt to maintain the alternate through the rename so it really does act like a rename of the file and not a write and delete.
