### PR TITLE
Warn if Rename fails to delete the original file

### DIFF
--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -23,7 +23,9 @@ command! -bar -nargs=1 -bang -complete=file Rename :
       \ setlocal modified |
       \ keepalt saveas<bang> <args> |
       \ if s:file !=# expand('%:p') |
-      \   call delete(s:file) |
+      \   if delete(s:file) |
+      \     echoerr 'Failed to delete "'.s:file.'"' |
+      \   endif |
       \ endif |
       \ unlet s:file
 


### PR DESCRIPTION
When Renaming a file, report an error if delete() returns failure
(nonzero). When the user asks for a move but we do a copy, we should
tell them that we didn't do what they expected.
