### PR TITLE
Change :Rename to use the file's current directory by default

### DIFF
--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -20,8 +20,9 @@ command! -bar -bang Remove :Unlink<bang>
 
 command! -bar -nargs=1 -bang -complete=file Rename :
       \ let s:file = expand('%:p') |
+      \ let s:arg = <q-args> =~# '/' ? <q-args> : expand('%:h').'/'.<q-args> |
       \ setlocal modified |
-      \ keepalt saveas<bang> <args> |
+      \ execute 'keepalt saveas<bang> '.s:arg |
       \ if s:file !=# expand('%:p') |
       \   if delete(s:file) |
       \     echoerr 'Failed to delete "'.s:file.'"' |
@@ -29,7 +30,7 @@ command! -bar -nargs=1 -bang -complete=file Rename :
       \     execute 'bwipe '.fnameescape(s:file) |
       \   endif |
       \ endif |
-      \ unlet s:file
+      \ unlet s:file s:arg
 
 command! -bar -bang -complete=file -nargs=+ Find   :call s:Grep(<q-bang>, <q-args>, 'find')
 command! -bar -bang -complete=file -nargs=+ Locate :call s:Grep(<q-bang>, <q-args>, 'locate')


### PR DESCRIPTION
Let's say you're in `project/` and you're editing `src/feature/blue.c`. You make a bunch of changes and decide that it really should be named `red.c` now, so you `:Rename red.c`.

Now you've got `project/red.c` in your root project directory and nothing in `src/feature`.

This patch makes `:Rename` use the directory of the original file if no path fragment is specified.

You can still get the original behavior by doing e.g. `:Rename ./red.c` in the above example.
