### PR TITLE
Show output of :SudoWrite

### DIFF
--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -65,7 +65,7 @@ endfunction
 
 command! -bar SudoWrite :
       \ setlocal nomodified |
-      \ silent exe 'write !sudo tee % >/dev/null' |
+      \  exe (has('gui_running') ? '' : 'silent') 'write !sudo tee % >/dev/null' |
       \ let &modified = v:shell_error
 
 command! -bar W :call s:W()


### PR DESCRIPTION
When using SudoWrite, the output of sudo gives essential information for
the user (password prompt, wrong password typed, etc.).
Hence, its output should not be silenced.
