### PR TITLE
Rename_complete: keep current file with completions

### DIFF
--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -77,7 +77,6 @@ function! s:Rename_complete(A, L, P) abort
   let sep = s:separator()
   let prefix = expand('%:p:h').sep
   let files = split(glob(prefix.a:A.'*'), "\n")
-  call filter(files, 'simplify(v:val) !=# simplify(expand("%:p"))')
   call map(files, 'v:val[strlen(prefix) : -1] . (isdirectory(v:val) ? sep : "")')
   return join(files + ['..'.s:separator()], "\n")
 endfunction


### PR DESCRIPTION
While I can see why the current file would get removed from the
completion, it's a common use case to rename a file based on its current
name.  Therefore it should be kept in the list in general.

I've changed it to remove any extension of the current file.  The idea
was to support the use case of changing the file type, but that might be
not so common after all.

Maybe just the `call filter(files, 'simplify(v:val) !=#
simplify(expand("%:p"))')` should get removed?
