### PR TITLE
Rm swp command

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,6 +4,7 @@ Vim sugar for the UNIX shell commands that need it the most.  Features
 include:
 
 * `:Remove`: Delete a buffer and the file on disk simultaneously.
+*  `:RmSwp`: Delete the current buffer file's swap.
 * `:Unlink`: Like `:Remove`, but keeps the now empty buffer.
 * `:Move`: Rename a buffer and the file on disk simultaneously.
 * `:Chmod`: Change the permissions of the current file.

--- a/doc/eunuch.txt
+++ b/doc/eunuch.txt
@@ -26,6 +26,9 @@ COMMANDS                                        *eunuch-commands*
                         disk.  If a bang is given, it is passed along to
                         :bdelete.
 
+                                                *eunuch-:RmSwp*
+:RmSwp                  Delete the current buffer file's swap.
+
                                                 *eunuch-:Unlink*
 :Unlink[!]              Delete the file from disk and reload the buffer.
                         If a bang is given, discard unsaved changes.

--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -38,6 +38,14 @@ command! -bar -bang Remove
       \ endif |
       \ unlet s:file
 
+command! -bar RmSwp
+      \ let s:file = bufname(<q-args>) |
+      \ let s:file = '.'.s:file.'.swp' |
+      \ if delete(s:file) |
+      \   echoerr 'Failed to delete "'.s:file.'"' |
+      \ endif |
+      \ unlet s:file
+
 command! -bar -nargs=1 -bang -complete=file Move :
       \ let s:src = expand('%:p') |
       \ let s:dst = expand(<q-args>) |


### PR DESCRIPTION
I found that this command would fit well inside this plugin and since I like organized things, I made a pull request for this for incorporating to newer versions.

I find the `RmSwp` command option is useful if you have just chosen to recover the file from the swap file `.file.swp` and everything is now saved to the file. Now what we want is delete the old swap file `.file.swp` since we already got a new one : `.file.swo`.

Hope that sounds useful to you !
