### PR TITLE
Write file before `:Move`

### DIFF
--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -39,6 +39,7 @@ command! -bar -bang Remove
       \ unlet s:file
 
 command! -bar -nargs=1 -bang -complete=file Move :
+      \ write |
       \ let s:src = expand('%:p') |
       \ let s:dst = expand(<q-args>) |
       \ if isdirectory(s:dst) || s:dst[-1:-1] =~# '[\\/]' |


### PR DESCRIPTION
Executing `:Move` on an unsaved buffer results in a Vim error. Writing
the file first gets it on disk and prevents errors from modified or
never-saved buffers blocking a user's clear intent to move the file
somewhere else.