### PR TITLE
Force Remove to happen, even if buffer modified

### DIFF
--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -30,9 +30,9 @@ command! -bar -bang Unlink
       \   edit! |
       \ endif
 
-command! -bar -bang Remove
+command! -bar Remove
       \ let s:file = fnamemodify(bufname(<q-args>),':p') |
-      \ execute 'bdelete<bang>' |
+      \ execute 'bdelete!' |
       \ if !bufloaded(s:file) && delete(s:file) |
       \   echoerr 'Failed to delete "'.s:file.'"' |
       \ endif |


### PR DESCRIPTION
`:Remove` should proceed even if the buffer has been modified previously. After all, we're deleting the file so it shouldn't matter whether it's been saved or not.
