### PR TITLE
Set VISUAL variable for sudo -e

### DIFF
--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -123,13 +123,13 @@ endfunction
 function! s:SudoReadCmd() abort
   silent %delete_
   let pipe = printf(&shellpipe . (&shellpipe =~ '%s' ? '' : ' %s'), '/dev/null')
-  execute (has('gui_running') ? '' : 'silent') 'read !env SUDO_EDITOR=cat sudo -e "%" ' . pipe
+  execute (has('gui_running') ? '' : 'silent') 'read !env SUDO_EDITOR=cat VISUAL=cat sudo -e "%" ' . pipe
   silent 1delete_
   set nomodified
 endfunction
 
 function! s:SudoWriteCmd() abort
-  execute (has('gui_running') ? '' : 'silent') 'write !env SUDO_EDITOR=tee sudo -e "%" >/dev/null'
+  execute (has('gui_running') ? '' : 'silent') 'write !env SUDO_EDITOR=tee VISUAL=tee sudo -e "%" >/dev/null'
   let &modified = v:shell_error
 endfunction
 


### PR DESCRIPTION
The SUDO_EDITOR variable is a *relatively* recent addition to sudo while the VISUAL and EDITOR variables are also honored (in that order).

This request is to enable consistent support across older sudo implementations by simply adding the VISUAL variable in addition to the SUDO_EDITOR variable currently being used.