### PR TITLE
Allow spaces in shebang line

### DIFF
--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -244,7 +244,7 @@ augroup eunuch
   autocmd BufWritePost * unlet! b:brand_new_file
   autocmd BufWritePre *
         \ if exists('b:brand_new_file') |
-        \   if getline(1) =~ '^#!/' |
+        \   if getline(1) =~ '^#!\s*/' |
         \     let b:chmod_post = '+x' |
         \   endif |
         \ endif


### PR DESCRIPTION
I put spaces between `#!` and `/executable`, which is allowed as per
[this QA](https://unix.stackexchange.com/questions/276751/is-space-allowed-between-and-bin-bash-in-shebang) which quotes Dennis Ritchie.

The regex changed to exclude this pattern in #52.