### PR TITLE
Refresh a vim split with :e after moving a file

### DIFF
--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -112,7 +112,8 @@ command! -bar -nargs=1 -bang -complete=file Move
       \ endif |
       \ unlet s:src |
       \ unlet s:dst |
-      \ filetype detect
+      \ filetype detect |
+      \ execute 'e'
 
 function! s:Rename_complete(A, L, P) abort
   let sep = s:separator()


### PR DESCRIPTION
This modification reloads the file after moving it with ':Move' or ':Rename'.
The reloading triggers the `BufEnter` event, signaling plugins and `autocmd`s that the file path has changed.

Do you like to merge it in?