### PR TITLE
Allow specifying a custom :bdelete command

### DIFF
--- a/doc/eunuch.txt
+++ b/doc/eunuch.txt
@@ -22,9 +22,13 @@ based on the original file name.
 COMMANDS                                        *eunuch-commands*
 
                                                 *eunuch-:Delete*
+                                                *g:eunuch_bdelete_command*
 :Delete[!]              |:bdelete|, and, if successful, delete the file from
                         disk.  If a bang is given, it is passed along to
-                        :bdelete.
+                        :bdelete. For integration with plugins such as vim-bbye
+                        and Bclose.vim, an alternative :bdelete command can be
+                        specified with g:eunuch_bdelete_command (by default
+                        :Bdelete will be tried automatically).
 
                                                 *eunuch-:Unlink*
 :Unlink[!]              Delete the file from disk and reload the buffer.

--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -73,11 +73,13 @@ command! -bar -bang Remove Unlink<bang>
 
 command! -bar -bang Delete
       \ let s:file = fnamemodify(bufname(<q-args>),':p') |
-      \ execute 'bdelete<bang>' |
+      \ let s:bdelete_cmd = get(g:, 'eunuch_bdelete_command', 'Bdelete') |
+      \ execute (exists(':' . s:bdelete_cmd) == 2 ? s:bdelete_cmd : 'bdelete') . '<bang>' |
       \ if !bufloaded(s:file) && s:fcall('delete', s:file) |
       \   echoerr 'Failed to delete "'.s:file.'"' |
       \ endif |
-      \ unlet s:file
+      \ unlet s:file |
+      \ unlet s:bdelete_cmd
 
 command! -bar -nargs=1 -bang -complete=file Move
       \ let s:src = expand('%:p') |


### PR DESCRIPTION
This is for integration with plugins such as [vim-bbye](https://github.com/moll/vim-bbye) and [Bclose.vim](https://github.com/rbgrouleff/bclose.vim) which let you delete the buffer without also closing the windows containing it.