### PR TITLE
Adds an option to choose whether ':Delete' can keep the windows open.

### DIFF
--- a/doc/eunuch.txt
+++ b/doc/eunuch.txt
@@ -89,6 +89,17 @@ COMMANDS                                        *eunuch-commands*
                         doubles as a safe fallback for people who, like me,
                         accidentally type :W instead of :w a lot.
 
+OPTIONS                                         *eunuch-options*
+
+                                *eunuch-g:eunuch_delete_keeps_windows_open*
+g:eunuch_delete_keeps_windows_open   Choose whether ':Delete' can keep the
+                                     windows that contain the current
+                                     buffer open.
+                                     Values:
+                                       1: It will keep the windows open.
+                                       0: It will close the windows.
+                                     Default value: 0.
+
 ABOUT                                           *eunuch-about*
 
 Grab the latest version or report a bug on GitHub:


### PR DESCRIPTION
This pull request adds an option that allows the user to choose whether `:Delete` can keep the windows that contain the buffer of the current file open.

`let g:eunuch_delete_keeps_windows_open = 1` will make `:Delete` keep the windows that contain the current buffer open. It will:
1. Edit a new, unnamed buffer on all the windows that contain the current buffer.
2. Delete the buffer.
3. Delete the file.

The default value is:
`let g:eunuch_delete_keeps_windows_open = 0`
(same behavior as before).