### PR TITLE
Make ':Remove' keep the windows open

### DIFF
--- a/doc/eunuch.txt
+++ b/doc/eunuch.txt
@@ -31,7 +31,9 @@ COMMANDS                                        *eunuch-commands*
                         If a bang is given, discard unsaved changes.
 
                                                 *eunuch-:Remove*
-:Remove[!]              Alias for :Unlink.
+:Remove[!]              Delete the file from disk and edit a new, unnamed
+                        buffer in all the windows that contain the current
+                        buffer. If a bang is given, discard unsaved changes.
 
                                                 *eunuch-:Move*
 :Move[!] {file}         Like |:saveas|, but delete the old file afterwards.

--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -69,7 +69,34 @@ command! -bar -bang Unlink
       \   silent exe 'doautocmd' s:nomodeline 'User FileUnlinkPost' |
       \ endif
 
-command! -bar -bang Remove Unlink<bang>
+function! s:Remove(bang) abort
+  let l:filename = expand('%')
+  let l:bufnr = bufnr()
+
+  if &buftype !=# ''
+    echoerr 'Unsupported buffer type: ' . &buftype
+    return
+  endif
+
+  if !a:bang && &modified
+    echoerr 'No write since last change for buffer ' . l:bufnr .
+          \ ' (add ! to override)'
+    return
+  endif
+
+  if l:filename !=# ''
+    if s:fcall('delete', l:filename)
+      echoerr 'Failed to delete "'. l:filename .'"'
+      return
+    endif
+  endif
+
+  for l:win_id in win_findbuf(l:bufnr)
+    call win_execute(l:win_id, 'enew' . ((a:bang) ? '!' : ''))
+  endfor
+endfunction
+
+command! -bar -bang Remove call s:Remove(<bang>0)
 
 command! -bar -bang Delete
       \ let s:file = fnamemodify(bufname(<q-args>),':p') |


### PR DESCRIPTION
This pull request will make `:Remove` keep the windows that contain the buffer of the current file open (useful to preserve the layout of windows/splits).

`:Remove` will:
- Edit a new, unnamed buffer in all the windows that contain the current buffer.
- Delete the file.
- Keep the buffer open.

If a bang is given to `:Remove!`, it will discard unsaved changes.