### PR TITLE
Substitute '<' with '<Lt>' of previous <CR> mapping in MapCR

### DIFF
--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -402,6 +402,7 @@ function! s:MapCR() abort
   imap <silent><script> <SID>EunuchNewLine <C-R>=EunuchNewLine()<CR>
   let map = maparg('<CR>', 'i', 0, 1)
   let rhs = substitute(maparg('<CR>', 'i'), '|', '<Bar>', 'g')
+  let rhs = substitute(rhs, '<', '<Lt>', 'g')
   if get(g:, 'eunuch_no_maps') || rhs =~# 'Eunuch' || get(map, 'buffer')
     return
   endif

--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -401,8 +401,8 @@ endfunction
 function! s:MapCR() abort
   imap <silent><script> <SID>EunuchNewLine <C-R>=EunuchNewLine()<CR>
   let map = maparg('<CR>', 'i', 0, 1)
-  let rhs = substitute(maparg('<CR>', 'i'), '|', '<Bar>', 'g')
-  let rhs = substitute(rhs, '<', '<Lt>', 'g')
+  let rhs = substitute(maparg('<CR>', 'i'), '<', '<Lt>', 'g')
+  let rhs = substitute(rhs, '|', '<Bar>', 'g')
   if get(g:, 'eunuch_no_maps') || rhs =~# 'Eunuch' || get(map, 'buffer')
     return
   endif


### PR DESCRIPTION
Currently vim-eunuchs `<CR>` mapping breaks leximas (and potentially other plugins') wrapped mapping, as `<` doesn't get properly escaped in the rhs of the `<CR>` mapping vim-eunuch's mapping wraps.

This PR attempts to fix this.

### Example
vim-eunuch currently wraps leximas mapping like this (simplified):
```
inoremap <expr> <CR> EunuchNewLine(lexima#expand('<CR>', 'i'))
```
but it should be
```
inoremap <expr> <CR> EunuchNewLine(lexima#expand('<Lt>CR>', 'i'))
```