### PR TITLE
Replace `/bin/sh` with `sh`

### DIFF
--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -370,8 +370,8 @@ endfunction
 
 " Adapted from autoload/dist/script.vim.
 let s:interpreters = {
-      \ '.': '/bin/sh',
-      \ 'sh': '/bin/sh',
+      \ '.': 'sh',
+      \ 'sh': 'sh',
       \ 'bash': 'bash',
       \ 'csh': 'csh',
       \ 'tcsh': 'tcsh',


### PR DESCRIPTION
All of the other shebangs do not have the leading `/bin/` so I think it is appropriate to do the same for `sh`.