### PR TITLE
Restore sudoedit filetype detection

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,6 +16,7 @@ include:
   [guard][].
 * `:SudoWrite`: Write a privileged file with `sudo`.
 * `:SudoEdit`: Edit a privileged file with `sudo`.
+* File type detection for `sudo -e` is based on original file name.
 * Typing a shebang line causes the file type to be re-detected.  Additionally
   the file will be automatically made executable (`chmod +x`) after the next
   write.

--- a/doc/eunuch.txt
+++ b/doc/eunuch.txt
@@ -98,7 +98,8 @@ COMMANDS                                        *eunuch-commands*
 PASSIVE BEHAVIORS                               *eunuch-passive*
 
 File type detection for files edited with `sudoedit` and `sudo -e` happens
-based on the original file name.
+based on the original file name, as found in the proc filesystem, and
+currently works only on Linux.
 
 If you type a line at the beginning of a file that starts with #! and press
 <CR>, The current file type will be re-detected.  This is implemented using a

--- a/doc/eunuch.txt
+++ b/doc/eunuch.txt
@@ -99,7 +99,7 @@ PASSIVE BEHAVIORS                               *eunuch-passive*
 
 File type detection for files edited with `sudoedit` and `sudo -e` happens
 based on the original file name, as found in the proc filesystem, and
-currently works only on Linux.
+currently works only on Linux and BSD.
 
 If you type a line at the beginning of a file that starts with #! and press
 <CR>, The current file type will be re-detected.  This is implemented using a

--- a/doc/eunuch.txt
+++ b/doc/eunuch.txt
@@ -98,7 +98,7 @@ COMMANDS                                        *eunuch-commands*
 PASSIVE BEHAVIORS                               *eunuch-passive*
 
 File type detection for files edited with `sudoedit` and `sudo -e` happens
-based on the original file name, as found in $SUDO_COMMAND.
+based on the original file name.
 
 If you type a line at the beginning of a file that starts with #! and press
 <CR>, The current file type will be re-detected.  This is implemented using a

--- a/doc/eunuch.txt
+++ b/doc/eunuch.txt
@@ -97,6 +97,9 @@ COMMANDS                                        *eunuch-commands*
 
 PASSIVE BEHAVIORS                               *eunuch-passive*
 
+File type detection for files edited with `sudoedit` and `sudo -e` happens
+based on the original file name, as found in $SUDO_COMMAND.
+
 If you type a line at the beginning of a file that starts with #! and press
 <CR>, The current file type will be re-detected.  This is implemented using a
 <CR> map.  If you already have a <CR> map, Eunuch will attempt to combine with

--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -362,13 +362,15 @@ command! -bar -bang SudoWrite
       \ write!
 endif
 
-let ppid = matchlist(readfile('/proc/self/status'), '^PPid:\s\+\(\d\+\)')[1]
-let s:parent_cmdline = split(readfile('/proc/' . ppid . '/cmdline')[0], '\n')
+if has('linux')
+  let ppid = matchlist(readfile('/proc/self/status'), '^PPid:\s\+\(\d\+\)')[1]
+  let s:parent_cmdline = split(readfile('/proc/' . ppid . '/cmdline')[0], '\n')
 
-if s:parent_cmdline[0] ==# 'sudoedit'
-  let s:sudo_files_offset = 1
-elseif s:parent_cmdline[0] ==# 'sudo' && s:parent_cmdline[1] ==# '-e'
-  let s:sudo_files_offset = 2
+  if s:parent_cmdline[0] ==# 'sudoedit'
+    let s:sudo_files_offset = 1
+  elseif s:parent_cmdline[0] ==# 'sudo' && s:parent_cmdline[1] ==# '-e'
+    let s:sudo_files_offset = 2
+  endif
 endif
 
 function! s:SudoEditInit() abort

--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -363,8 +363,13 @@ command! -bar -bang SudoWrite
 endif
 
 if has('linux')
-  let ppid = matchlist(readfile('/proc/self/status'), '^PPid:\s\+\(\d\+\)')[1]
-  let s:parent_cmdline = split(readfile('/proc/' . ppid . '/cmdline')[0], '\n')
+  let s:ppid = matchlist(readfile('/proc/self/status'), '^PPid:\s\+\(\d\+\)')[1]
+elseif has('bsd')
+  let s:ppid = split(readfile('/proc/curproc/status')[0], ' ')[2]
+endif
+
+if exists('s:ppid')
+  let s:parent_cmdline = split(readfile('/proc/' . s:ppid . '/cmdline')[0], '\n')
 
   if s:parent_cmdline[0] ==# 'sudoedit'
     let s:sudo_files_offset = 1

--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -362,6 +362,21 @@ command! -bar -bang SudoWrite
       \ write!
 endif
 
+function! s:SudoEditInit() abort
+  let files = split($SUDO_COMMAND, ' ')[1:-1]
+  if len(files) ==# argc()
+    for i in range(argc())
+      execute 'autocmd BufEnter' fnameescape(argv(i))
+            \ 'if empty(&filetype) || &filetype ==# "conf"'
+            \ '|doautocmd filetypedetect BufReadPost' fnameescape(files[i])
+            \ '|endif'
+    endfor
+  endif
+endfunction
+if $SUDO_COMMAND =~# '^sudoedit '
+  call s:SudoEditInit()
+endif
+
 command! -bar Wall call s:Wall()
 if exists(':W') !=# 2
   command! -bar W Wall


### PR DESCRIPTION
This PR is a proposal to fix #31 by using the proc filesystem to determine the original filenames from the command line of the parent process when using `sudoedit` or `sudo -e` to edit files.

Main details of this approach:

- get the PID of the parent process from the `PPid:` line of `/proc/self/status`
- get the command line of the parent process from `/proc/<ppid>/cmdline` which holds a list of arguments separated by null bytes
- checking for `sudoedit` or `sudo -e` at the beginning of the parent command line, and setting an offset to file arguments starting index

It is a follow-up on previous discussions on #31 and #79, and in response to

> not ruling out pursuing a more robust solution

in [this comment](https://github.com/tpope/vim-eunuch/pull/79#issuecomment-1093647856).

While I’m lacking the exact criteria for a solution to be considered “robust” for vim-eunuch purposes, this approach does address the known concerns from previous attempts:

- it doesn’t use `system` calls
- filename detection is more portable
- works with filenames containing spaces

I tested this on successfully on:

- Linux in the past few days (Gentoo with kernel 6.1.12; please test more)
- FreeBSD 13.2 briefly in a VM (I'm not a BSD user though, and had to manually mount procfs first; please test more)

I'm also not a Mac OS X user, but it does not seem to have a procfs out-of-the-box that we could use in a similar manner. There are apparently third-party solutions like [kimtopley/ProcFS](https://github.com/kimtopley/ProcFS) which sounds like a weird dependency, or we may opt for a `system()` based approach via `ps` commands (with the remark that on previous attempts this was discouraged).

Anyone testing should be aware that this seems to conflict with current latest version of vim-polyglot, so best to disable that before trying this patch.

I’m opening it as a draft pull request only at first in order to learn more and gather further feedback.

My main questions at this stage:

- Would this first draft be an acceptable direction? Shall I keep investing effort in it?
- This is my first contribution attempt with vimscript. Are there better ways to obtain and process this info from procfs?
- Is it OK to have it only on Linux and optionally on BSD?
- What else we may attempt on Mac OS X to obtain parent process ID, and/or parent process command line (command + arguments)?

Please review, and let me know how to improve it further. I'm also happy to reorganize commits into a different history if desired.