### PR TITLE
Make :Cfind try to use unix find on win32

### DIFF
--- a/plugin/eunuch.vim
+++ b/plugin/eunuch.vim
@@ -219,9 +219,25 @@ endfunction
 command! -bar -bang -nargs=+ Chmod
       \ exe s:Chmod(<bang>0, <f-args>)
 
-command! -bang -complete=file -nargs=+ Cfind   exe s:Grep(<q-bang>, <q-args>, 'find', '')
+function! s:FindPath() abort
+  if !has('win32')
+    return 'find'
+  elseif !exists('s:find_path')
+    let s:find_path = 'find'
+    for p in split($PATH, ';')
+      let prg_path = p ..'/find'
+      if p !~? '\<System32\>' && executable(prg_path)
+        let s:find_path = prg_path
+        break
+      endif
+    endfor
+  endif
+  return s:find_path
+endf
+
+command! -bang -complete=file -nargs=+ Cfind   exe s:Grep(<q-bang>, <q-args>, s:FindPath(), '')
 command! -bang -complete=file -nargs=+ Clocate exe s:Grep(<q-bang>, <q-args>, 'locate', '')
-command! -bang -complete=file -nargs=+ Lfind   exe s:Grep(<q-bang>, <q-args>, 'find', 'l')
+command! -bang -complete=file -nargs=+ Lfind   exe s:Grep(<q-bang>, <q-args>, s:FindPath(), 'l')
 command! -bang -complete=file -nargs=+ Llocate exe s:Grep(<q-bang>, <q-args>, 'locate', 'l')
 function! s:Grep(bang, args, prg, type) abort
   let grepprg = &l:grepprg


### PR DESCRIPTION
I've seen #94 and #102, but I think the objections are to using nonstandard unix find.

However, on Windows find.exe doesn't work at all like unix find. I **want** that consistent `:Find` behaviour across platforms.

I can install msys or git-for-windows to get unix find, but putting its bin/ at the beginning of my PATH breaks other tools (scripts from my non-unixy team that use windows find.exe).

Instead, make eunuch avoid Windows find if there's an alternative by checking for System32 to ignore windows find.exe if any alternative is available.

The output for `where` is similar to unix `which`:

	> where find
	C:\Windows\System32\find.exe
	C:\Users\idbrii\scoop\apps\git\current\usr\bin\find.exe



Test
* Use `:Cfind . -name *.vim` from ~/.vim/bundle/eunuch/ in gvim on windows 10 and vim on ubuntu WSL.